### PR TITLE
OAuth2 쿠키 설정 수정 - SameSite 속성 변경 및 리다이렉트 경로 수정

### DIFF
--- a/src/main/java/com/zb/jogakjogak/security/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/zb/jogakjogak/security/oauth2/CustomSuccessHandler.java
@@ -53,19 +53,15 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         addRefreshToken(username, refreshToken);
         addSameSiteCookieAttribute(request, response, "refresh", refreshToken);
   
-        response.setContentType("text/html;charset=UTF-8");
-        PrintWriter writer = response.getWriter();
-        writer.println("""
-            <html>
-              <head><meta charset='UTF-8'></head>
-              <body>
-                <script>
-                  window.location.href = 'https://www.jogakjogak.com/login/oauth2/code/kakao';
-                </script>
-              </body>
-            </html>
-        """);
-        writer.flush();
+        // 환경에 따라 리다이렉트 URL 결정
+        String redirectUrl;
+        if (request.getServerName().contains("localhost")) {
+            redirectUrl = "http://localhost:3000/login/oauth2/code/kakao";
+        } else {
+            redirectUrl = "https://www.jogakjogak.com/login/oauth2/code/kakao";
+        }
+        
+        response.sendRedirect(redirectUrl);
     }
 
     private String getRole(Authentication authentication){
@@ -92,7 +88,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         } else {
             // 프로덕션 환경
             cookieHeader = String.format(
-                "%s=%s; Max-Age=%d; Path=/; Domain=.jogakjogak.com; HttpOnly; SameSite=Lax; Secure",
+                "%s=%s; Max-Age=%d; Path=/; Domain=.jogakjogak.com; HttpOnly; SameSite=None; Secure",
                 cookieName,
                 cookieValue,
                 60 * 60 * 24 * 7


### PR DESCRIPTION
## Summary
  - OAuth2 로그인 후 프론트엔드에서 쿠키를 읽지 못하는 문제 해결
  - Cross-site 요청에서 쿠키 전송을 위한 SameSite 속성 수정

  ## Changes
  - OAuth2 인증 성공 후 리다이렉트 경로를 프론트엔드 콜백 페이지로 변경
    - 기존: `/` (메인 페이지)
    - 변경: `/login/oauth2/code/kakao` (콜백 페이지)
  - 프로덕션 환경 쿠키 설정 변경
    - SameSite: `Lax` → `None` (cross-site 요청 허용)
    - Domain: `.jogakjogak.com` 유지 (www 서브도메인 포함)
  - 환경별 리다이렉트 URL 처리
    - 로컬: `http://localhost:3000/login/oauth2/code/kakao`
    - 프로덕션: `https://www.jogakjogak.com/login/oauth2/code/kakao`