### PR TITLE
OAuth2 리다이렉트 URI를 API 도메인으로 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,14 +43,14 @@ spring:
               - name
               - phone_number
             authorization-grant-type: authorization_code
-            redirect-uri: https://jogakjogak.com/login/oauth2/code/kakao
+            redirect-uri: https://api.jogakjogak.com/login/oauth2/code/kakao
             client-name: Kakao
             client-authentication-method: client_secret_post
 
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: https://jogakjogak.com/login/oauth2/code/google
+            redirect-uri: https://api.jogakjogak.com/login/oauth2/code/google
             authorization-grant-type: authorization_code
             scope:
               - profile


### PR DESCRIPTION
## Changes
- 카카오 OAuth2 redirect-uri: `https://jogakjogak.com` → `https://api.jogakjogak.com`
- 구글 OAuth2 redirect-uri: `https://jogakjogak.com` → `https://api.jogakjogak.com`