### PR TITLE
이메일 알림 발송시 notification 저장안되는 버그 수정

### DIFF
--- a/src/main/java/com/zb/jogakjogak/notification/config/NotificationBatchConfig.java
+++ b/src/main/java/com/zb/jogakjogak/notification/config/NotificationBatchConfig.java
@@ -4,6 +4,8 @@ package com.zb.jogakjogak.notification.config;
 import com.zb.jogakjogak.jobDescription.entity.JD;
 import com.zb.jogakjogak.jobDescription.repository.JDRepository;
 import com.zb.jogakjogak.notification.dto.NotificationDto;
+import com.zb.jogakjogak.notification.entity.Notification;
+import com.zb.jogakjogak.notification.repository.NotificationRepository;
 import com.zb.jogakjogak.notification.service.NotificationService;
 import com.zb.jogakjogak.security.entity.Member;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +40,7 @@ public class NotificationBatchConfig {
     private static final int RETRY_LIMIT = 3;
     private static final int SKIP_SIZE = 10;
     private static final int NOTIFICATION_THRESHOLD_DAYS = 1;
+    private final NotificationRepository notificationRepository;
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;
     private final JDRepository jdRepository;
@@ -116,10 +119,19 @@ public class NotificationBatchConfig {
                         .build();
                 try {
                     notificationService.sendNotificationEmail(notificationDto);
+                    saveNotification(notificationDto);
                 } catch (Exception e) {
                     log.warn("이메일 전송에 실패했습니다. memberId={}, error={}", member.getId(), e.getMessage());
                 }
             }
         };
+    }
+    public void saveNotification(NotificationDto notificationDto){
+        Notification notification = Notification.builder()
+                .member(notificationDto.getMember())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        notificationRepository.save(notification);
     }
 }

--- a/src/main/java/com/zb/jogakjogak/notification/service/NotificationService.java
+++ b/src/main/java/com/zb/jogakjogak/notification/service/NotificationService.java
@@ -7,6 +7,8 @@ import com.zb.jogakjogak.jobDescription.repository.ToDoListRepository;
 import com.zb.jogakjogak.notification.dto.NotificationDto;
 import com.zb.jogakjogak.notification.dto.EmailTemplateDto;
 import com.zb.jogakjogak.notification.dto.JdEmailDto;
+import com.zb.jogakjogak.notification.entity.Notification;
+import com.zb.jogakjogak.notification.repository.NotificationRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class NotificationService {
     private final JavaMailSender javaMailSender;
     private final SpringTemplateEngine templateEngine;
     private final ToDoListRepository toDoListRepository;
+    private final NotificationRepository notificationRepository;
     private final GaMeasurementProtocolService gaService;
 
     @Async("taskExecutor")


### PR DESCRIPTION
<!-- #3 feature:mallangc -> 코멘트 기능 -->
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#112 
## 📝 요약(Summary)
- 알림발송후 DB에 notification 정보가 저장이 안되어서 수정했습니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
